### PR TITLE
SAM demo updates

### DIFF
--- a/demo/sam/README.md
+++ b/demo/sam/README.md
@@ -4,10 +4,10 @@
 
 This demo is compatible with three runtimes: PyTorch, ONNX, and TensorRT.  The demo allows experimentation with all five versions of our model: l0, l1, l2, xl0, and xl1.  
 
-Please follow the [Getting Started](../README.md#getting-started) instructions, then follow the runtime-specific instructions below.
+Please follow the [Getting Started](../../README.md#getting-started) instructions, then follow the runtime-specific instructions below.
 
 ### PyTorch-specific installation instructions
-1. Please download the model checkpoint files listed [here](../applications/sam.md#pretrained-models) and save them to the `assets/checkpoints` directory.
+1. Please download the model checkpoint files listed [here](../../applications/sam.md#pretrained-models) and save them to the `assets/checkpoints` directory.
 
 ### ONNX-specific installation instructions
 1. Create ONNX models
@@ -22,7 +22,7 @@ Please follow the [Getting Started](../README.md#getting-started) instructions, 
 
 ### TensorRT-specific installation instructions
 
-1. Please ensure you have CUDA working properly and the packages below installed.
+1. Please ensure you have CUDA working properly and the following packages installed.
 
     a. [tensorrt](https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html)
 
@@ -51,14 +51,19 @@ For users with GPU access, we recommend using the PyTorch runtime to start and e
 
 We offer point-prompted, box-prompted, mixed prompt, and automatically generated image segmentation modes.
 
+A left click creates a positive foreground prompt.  A right click (two-fingered click using Mac trackpad) creates a negative background prompt that works to exclude objects from the segmentation.
+
 For our point-prompted mode and mixed prompt mode, all prompts will go towards segmenting a single object.  For example, if multiple points are added to the image, all points are assumed to be segmenting the same object.  In our mixed prompt mode, we enforce this by only taking into account the last drawn box prompt (with no restriction on the number of point prompts).
 
 For our box-prompted mode, each box goes towards segmenting a separate object.
 
 Our full image segmentation mode automatically generates segmentations over the full image.  The segmentation parameters in the slider will change the number and granularity of the final masks displayed.  Feel free to play around with these parameters and reset them to the defaults with the "reset segmentation parameters" button at the bottom.  The segmentation parameters are generally tuned towards our xl models.  When experimenting with our l-series models, you may get better full image segmentation results by changing the slider values.
 
+The models listed in the dropdown are based on the files you have stored in the default installation directories.  Please ensure you save your models using the instructions above.
+
 Either use the images shown in the example bar at the bottom of the demo by clicking on the image, uploading your own image, or clicking the webcam icon to take a picture. 
+
 
 ### Contributor
 
-[Nicole C Stiles](https://github.com/ncstiles)
+[Nicole Stiles](https://github.com/ncstiles)

--- a/demo/sam/helpers/auto_mask_generator.py
+++ b/demo/sam/helpers/auto_mask_generator.py
@@ -59,7 +59,12 @@ class DemoAccelEfficientViTSamAutomaticMaskGenerator(DemoEfficientViTSamAutomati
     ) -> MaskData:
         orig_h, orig_w = orig_size
 
-        masks, iou_preds = self.predictor.predict_torch(im_size=im_size, point_coords=points, return_logits=True)
+        point_labels = np.ones(points.shape[0], dtype=np.float32)
+        masks, iou_preds = self.predictor.predict_torch(
+            im_size=im_size, 
+            point_coords=points, 
+            point_labels=point_labels,
+            return_logits=True)
         
         # Serialize predictions and store in MaskData
         data = MaskData(

--- a/demo/sam/helpers/predictors/effvit_sam_tensorrt.py
+++ b/demo/sam/helpers/predictors/effvit_sam_tensorrt.py
@@ -84,6 +84,7 @@ class TRTEfficientViTSamPredictor:
         self,
         im_size: tuple[int, int],
         point_coords: np.ndarray = None,
+        point_labels: np.ndarray = None,
         point_expansion_axis: int = 1,
         boxes: np.ndarray = None,
         return_logits: bool = False,
@@ -97,6 +98,9 @@ class TRTEfficientViTSamPredictor:
           im_size (tuple[int, int]): size of the cropped image
           point_coords (np.ndarray or None): A Nx2 array of point prompts to the
             model. Each point is in (X,Y) in pixels.
+          point_labels (np.ndarray or None): A length N array of labels for the
+				point prompts. 1 indicates a foreground point and 0 indicates a
+				background point.
           point_expansion_axis (int): dim across which to expand points.  1 to place each
             point in its own batch, 0 to place all points in the same batch
           boxes (np.ndarray or None): A Nx4 array of box prompts
@@ -113,10 +117,9 @@ class TRTEfficientViTSamPredictor:
             raise RuntimeError("An image must be set with .set_image(...) before mask prediction.")
 
         if point_coords is not None:
-            point_labels = np.ones(point_coords.shape[0], dtype=np.float32)
             point_coords = np.expand_dims(point_coords, axis=point_expansion_axis)
             point_coords = apply_coords(point_coords, self.original_size, im_size).astype(np.float32)
-            point_labels = np.expand_dims(point_labels, axis=point_expansion_axis)
+            point_labels = np.expand_dims(point_labels, axis=point_expansion_axis).astype(np.float32)
 
             prompts, labels = point_coords, point_labels
         

--- a/demo/sam/helpers/segmentation/process_prompts_pytorch.py
+++ b/demo/sam/helpers/segmentation/process_prompts_pytorch.py
@@ -47,8 +47,8 @@ def segment_using_points_pytorch(prompt_dict, model_name):
     if len(points) == 0:
         return raw_image
 
-    point_coords = [(x, y) for x, y, _ in points]
-    point_labels = [l for _, _, l in points]
+    point_coords = points[..., :2]
+    point_labels = points[..., 2]
 
     efficientvit_sam_predictor.set_image(raw_image)
     masks, _, _ = efficientvit_sam_predictor.predict(
@@ -57,7 +57,7 @@ def segment_using_points_pytorch(prompt_dict, model_name):
         multimask_output=MUTLIMASK,
     )
 
-    return draw_point_masks(raw_image, masks, point_coords)
+    return draw_point_masks(raw_image, masks, points)
 
 
 def segment_using_boxes_pytorch(prompt_dict, model_name):
@@ -93,8 +93,8 @@ def segment_using_points_and_boxes_pytorch(prompt_dict, model_name):
     elif len(points) == 0:
         return segment_using_boxes_pytorch(prompt_dict, model_name)
 
-    point_coords = np.array([(x, y) for x, y, _ in points])
-    point_labels = np.array([l for _, _, l in points])
+    point_coords = points[..., :2]
+    point_labels = points[..., 2]
     boxes = np.array(boxes)
 
     efficientvit_sam_predictor.set_image(raw_image)
@@ -105,7 +105,7 @@ def segment_using_points_and_boxes_pytorch(prompt_dict, model_name):
         multimask_output=MUTLIMASK,
     )
 
-    return draw_point_and_box_masks(raw_image, masks, point_coords, boxes)
+    return draw_point_and_box_masks(raw_image, masks, points, boxes)
 
 
 def segment_full_img_pytorch(raw_image, model_name, points_per_batch, pred_iou_thresh, stability_score_thresh, box_nms_thresh):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ pycocotools
 
 # demo-specific packages
 gradio
+gradio-clickable-arrow-dropdown
 gradio-box-promptable-image
 gradio-point-promptable-image
 gradio-sbmp-promptable-image


### PR DESCRIPTION
- Enable both foreground (positive) and background (negative) point prompts by left-clicking and right-clicking, respectively.  Changes applicable to both point prompt mode and mixed prompt mode.

- Model dropdown's arrow now clickable.

- Models listed in the dropdown are based on the set of models saved locally to the default runtime-specific model storage directory.
