### PR TITLE
fix(pytorch): update autocast to prevent future deprecation issues

### DIFF
--- a/demo/gazesam/load_demo_models.py
+++ b/demo/gazesam/load_demo_models.py
@@ -131,7 +131,7 @@ def load_depth_model(mode, precision):
 
         encoder = "vitb"  # or 'vitb', 'vits'
         model = DepthAnything(model_configs[encoder])
-        model.load_state_dict(torch.load(f"{PYTORCH_MODEL_DIR}/depth_anything_{encoder}14.pth"))
+        model.load_state_dict(torch.load(f"{PYTORCH_MODEL_DIR}/depth_anything_{encoder}14.pth", weights_only=True))
         model = model.eval().cuda()
         return model
 

--- a/efficientvit/apps/trainer/base.py
+++ b/efficientvit/apps/trainer/base.py
@@ -242,7 +242,7 @@ class Trainer:
         print("Sync model")
         self.save_model(model_name="sync.pt")
         dist_barrier()
-        checkpoint = torch.load(os.path.join(self.checkpoint_path, "sync.pt"), map_location="cpu")
+        checkpoint = torch.load(os.path.join(self.checkpoint_path, "sync.pt"), map_location="cpu", weights_only=True)
         dist_barrier()
         if is_master():
             os.remove(os.path.join(self.checkpoint_path, "sync.pt"))

--- a/efficientvit/clscore/trainer/cls_trainer.py
+++ b/efficientvit/clscore/trainer/cls_trainer.py
@@ -121,7 +121,7 @@ class ClsTrainer(Trainer):
         else:
             ema_output = None
 
-        with torch.autocast(device_type="cuda", dtype=self.amp_dtype, enabled=self.enable_amp):
+        with torch.amp.autocast(device_type="cuda", dtype=self.amp_dtype, enabled=self.enable_amp):
             output = self.model(images)
             loss = self.train_criterion(output, labels)
             # mesa loss

--- a/efficientvit/models/nn/ops.py
+++ b/efficientvit/models/nn/ops.py
@@ -5,7 +5,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.cuda.amp import autocast
+from torch.amp import autocast
 
 from efficientvit.models.nn.act import build_act
 from efficientvit.models.nn.norm import build_norm
@@ -91,7 +91,7 @@ class UpSampleLayer(nn.Module):
         self.factor = None if self.size is not None else factor
         self.align_corners = align_corners
 
-    @autocast(enabled=False)
+    @autocast(device_type="cuda", enabled=False)
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if (self.size is not None and tuple(x.shape[-2:]) == self.size) or self.factor == 1:
             return x
@@ -395,7 +395,7 @@ class LiteMLA(nn.Module):
             act_func=act_func[1],
         )
 
-    @autocast(enabled=False)
+    @autocast(device_type="cuda", enabled=False)
     def relu_linear_att(self, qkv: torch.Tensor) -> torch.Tensor:
         B, _, H, W = list(qkv.size())
 
@@ -434,7 +434,7 @@ class LiteMLA(nn.Module):
         out = torch.reshape(out, (B, -1, H, W))
         return out
 
-    @autocast(enabled=False)
+    @autocast(device_type="cuda", enabled=False)
     def relu_quadratic_att(self, qkv: torch.Tensor) -> torch.Tensor:
         B, _, H, W = list(qkv.size())
 

--- a/efficientvit/models/utils/network.py
+++ b/efficientvit/models/utils/network.py
@@ -67,7 +67,7 @@ def build_kwargs_from_config(config: dict, target_func: callable) -> dict[str, a
 
 def load_state_dict_from_file(file: str, only_state_dict=True) -> dict[str, torch.Tensor]:
     file = os.path.realpath(os.path.expanduser(file))
-    checkpoint = torch.load(file, map_location="cpu")
+    checkpoint = torch.load(file, map_location="cpu", weights_only=True)
     if only_state_dict and "state_dict" in checkpoint:
         checkpoint = checkpoint["state_dict"]
     return checkpoint

--- a/efficientvit/samcore/trainer/sam_trainer.py
+++ b/efficientvit/samcore/trainer/sam_trainer.py
@@ -171,7 +171,7 @@ class SAMTrainer(Trainer):
 
             batched_input.append(dict_input)
 
-        with torch.autocast(device_type="cuda", dtype=self.amp_dtype, enabled=self.enable_amp):
+        with torch.amp.autocast(device_type="cuda", dtype=self.amp_dtype, enabled=self.enable_amp):
             if random.random() >= 0.5:
                 output, iou_predictions = self.model(batched_input, multimask_output=True)
             else:


### PR DESCRIPTION
Replace deprecated `torch.cuda.amp.autocast` with `torch.amp.autocast` and update usage accordingly in the codebase. This change aligns with the upcoming PyTorch version requirements and ensures better future compatibility.

#127 