### PR TITLE
Fixed set_image_batch using lower resolution as input_size

### DIFF
--- a/efficientvit/models/efficientvit/sam.py
+++ b/efficientvit/models/efficientvit/sam.py
@@ -343,7 +343,7 @@ class EfficientViTSamPredictor:
         original_height, original_width = image.shape[-2], image.shape[-1]
         self.original_size = (original_height, original_width)
         self.input_size = ResizeLongestSide.get_preprocess_shape(
-            *self.original_size, long_side_length=self.model.image_size[1]
+            *self.original_size, long_side_length=self.model.image_size[0]
         )
 
         self.features = self.model.image_encoder(image)


### PR DESCRIPTION
While doing more extensive tests I realized that the results obtained from `set_image_batch` could sometimes be worst when using a backbone that uses an image size of 512x512.    
After analyzing the `set_image_batch` function I realized that the wrong `input_size` is being set.   
This resulted in the masks being upscaled to the wrong resolution (eg: 512x512 instead of 1024x1024).  

This is PR fixes this issue.  
I have tested this change and I obtain exactly the same quality as `set_image` now. 